### PR TITLE
Revert "Hyper-threading false setting is not enabled when using autoscaling"

### DIFF
--- a/autoscaling/tf_init/bastion_update.tf
+++ b/autoscaling/tf_init/bastion_update.tf
@@ -46,7 +46,6 @@ resource "local_file" "inventory" {
     shape = var.cluster_network ? var.cluster_network_shape : var.instance_pool_shape,
     instance_pool_ocpus=var.instance_pool_ocpus,
     queue=var.queue,
-    hyperthreading=var.hyperthreading,
     instance_type=var.instance_type,
     autoscaling_monitoring = var.autoscaling_monitoring,
     unsupported = var.unsupported

--- a/autoscaling/tf_init/inventory.tpl
+++ b/autoscaling/tf_init/inventory.tpl
@@ -41,5 +41,4 @@ nfs_source_path=${nfs_source_path}
 nfs_options=${nfs_options}
 ldap=${ldap}
 queue=${queue}
-hyperthreading=${hyperthreading}
 instance_type=${instance_type}


### PR DESCRIPTION
Reverts oracle-quickstart/oci-hpc#5