### PR TITLE
Explicitly specify providers that are used

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,25 @@
 terraform {
   required_version = ">= 1.0"
   required_providers {
-     oci = {
-         source = "oracle/oci"
-         version = "4.99.0"
-     }
+    oci = {
+      source  = "oracle/oci"
+      version = "4.110.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.4.3"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = "2.2.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.4"
+    }
   }
 }


### PR DESCRIPTION
To prevent accidental breaks because provider versions are not pinned.