### PR TITLE
Fix: Enabled RDMA-related plugins for instances when using Compute Cluster

### DIFF
--- a/compute-nodes.tf
+++ b/compute-nodes.tf
@@ -26,7 +26,29 @@ resource "oci_core_instance" "compute_cluster_instances" {
 
   agent_config {
     is_management_disabled = true
+
+    plugins_config {
+      desired_state = "DISABLED"
+      name          = "OS Management Service Agent"
+      }
+
+    dynamic plugins_config {
+      for_each = var.use_compute_agent ? ["ENABLED"] : ["DISABLED"]
+        content {
+        name = "Compute HPC RDMA Authentication"
+        desired_state = plugins_config.value
+        }
+     }
+
+    dynamic plugins_config {
+      for_each = var.use_compute_agent ? ["ENABLED"] : ["DISABLED"]
+        content {
+        name = "Compute HPC RDMA Auto-Configuration"
+        desired_state = plugins_config.value
+        }
     }
+
+  }
 
   display_name        = "${local.cluster_name}-node-${var.compute_cluster_start_index+count.index}"
 


### PR DESCRIPTION
Hi @arnaudfroidmont

I've made this modification because when using the Compute Cluster, the following plugin for the instance did not enable, resulting in no IP address being assigned to the RoCEv2 interface.
- Compute HPC RDMA Auto-Configuration
- Compute HPC RDMA Authentication