### PR TITLE
[WIP] change to cross nic=2 to allow for alternating ring algo and nccl==2.23.4

### DIFF
--- a/samples/gpu/nccl_run_allreduce_containers_H100.sbatch
+++ b/samples/gpu/nccl_run_allreduce_containers_H100.sbatch
@@ -47,7 +47,6 @@ export NCCL_CROSS_NIC=2 \
        NCCL_IB_TC=41 \
        NCCL_IB_SL=0 \
        NCCL_IB_TIMEOUT=22 \
-       NCCL_NET_PLUGIN=none \
        NCCL_SOCKET_IFNAME=eth0 \
        NCCL_IGNORE_CPU_AFFINITY=1 \
        NCCL_IB_HCA="=mlx5_0,mlx5_1,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7,mlx5_8,mlx5_9,mlx5_10,mlx5_12,mlx5_13,mlx5_14,mlx5_15,mlx5_16,mlx5_17" \

--- a/samples/gpu/nccl_run_allreduce_containers_H100.sbatch
+++ b/samples/gpu/nccl_run_allreduce_containers_H100.sbatch
@@ -38,12 +38,11 @@ else
   echo "Use the appropriate nccl test run script for non H100 nodes"
 fi
 
-export NCCL_CROSS_NIC=0 \
-       NCCL_SOCKET_NTHREADS=16 \
+export NCCL_CROSS_NIC=2 \
        NCCL_DEBUG=WARN \
        NCCL_CUMEM_ENABLE=0 \
        NCCL_IB_SPLIT_DATA_ON_QPS=0 \
-       NCCL_IB_QPS_PER_CONNECTION=16 \
+       NCCL_IB_QPS_PER_CONNECTION=1 \
        NCCL_IB_GID_INDEX=3 \
        NCCL_IB_TC=41 \
        NCCL_IB_SL=0 \
@@ -52,7 +51,6 @@ export NCCL_CROSS_NIC=0 \
        NCCL_SOCKET_IFNAME=eth0 \
        NCCL_IGNORE_CPU_AFFINITY=1 \
        NCCL_IB_HCA="=mlx5_0,mlx5_1,mlx5_3,mlx5_4,mlx5_5,mlx5_6,mlx5_7,mlx5_8,mlx5_9,mlx5_10,mlx5_12,mlx5_13,mlx5_14,mlx5_15,mlx5_16,mlx5_17" \
-       NCCL_TOPO_FILE=/nfs/cluster/H100-topology.xml \
        HCOLL_ENABLE_MCAST_ALL=0 \
        coll_hcoll_enable=0 \
        UCX_TLS=tcp \
@@ -64,7 +62,7 @@ export NCCL_CROSS_NIC=0 \
 env | grep "SLURMD_NODENAME="
 USER=`whoami`
 
-CONTAINER_IMAGE="/home/ubuntu/nvcr.io+nvidia+pytorch+24.01-py3.sqsh"
+CONTAINER_IMAGE="nvcr.io#nvidia/pytorch:24.12-py3"
 CONTAINER_MOUNTS="/opt/oci-hpc/nccl-test:/nccl,$LOCAL_MPI:$LOCAL_MPI,/nfs/cluster:/nfs/cluster"
 echo $LOCAL_MPI
 echo $MPIVARS_PATH
@@ -75,5 +73,6 @@ srun --mpi=pmi2 --gpus-per-node=$SBATCH_GPUS_PER_NODE \
      --container-mounts=$CONTAINER_MOUNTS \
      bash -c "
      source $MPIVARS_PATH &&
-     /nccl/build/all_reduce_perf -b 1G -e 16G -f 2 -g 1
+     /nccl/build/all_reduce_perf -b 8 -e 16G -f 2 -g 1
      "
+


### PR DESCRIPTION
- [x] change to `NCCL_CROSS_NIC=2`
- [x] update from very old `nccl==2.19.4` in ngc 24.01 to `nccl==2.23.4` in ngc 24.12
- [x] change to `QPS_PER_CONNECTION=1`  when within the same rail group as there is no hash collisions within the same rail group
- [ ] TODO: add note about needing more QPs when about 1 tier of switching to increase enthropy
- [x]  remove nccl topo since NCCL graph search should be able to auto generate the topo on OCI's bare metal instances
- [x] remove NCCL_NET_PLUGIN=none 


max BW with alternating ring is 390GByte/s without it is 370GByte/s according to Sylvain's GTC24 NCCL talk

![image](https://github.com/user-attachments/assets/405f26db-cd5e-4321-8409-bcd6e70d435d)
![image](https://github.com/user-attachments/assets/3edabfca-2f5a-4e36-92a3-9234a1a284a0)
